### PR TITLE
Replace mandrill with Amazon SES for sending emails

### DIFF
--- a/dmutils/__init__.py
+++ b/dmutils/__init__.py
@@ -3,4 +3,4 @@ from .flask_init import init_app, init_manager
 
 import flask_featureflags
 
-__version__ = '21.1.0'
+__version__ = '23.0.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 boto==2.38.0
+boto3==1.3.1
 contextlib2==0.4.0
 Flask>=0.10
 six==1.9.0
@@ -6,7 +7,6 @@ pyyaml==3.11
 python-json-logger==0.1.4
 inflection==0.2.1
 Flask-FeatureFlags==0.6
-mandrill==1.0.57
 monotonic==0.3
 pytz==2015.4
 Flask-WTF==0.12

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 pytest==2.8.7
+nose==1.3.7
 mock==1.0.1
 pep8==1.6.2
 freezegun==0.3.4


### PR DESCRIPTION
Swaps mandrill client for boto3 SES API client.

Unlike Mandrill, SES will not send separate emails for multiple
recipients, so when sending an email to more than one address the
users will be able to see everyone else's address. This shouldn't
be a problem for registration/password reset emails since they're
sent to one user only.

Since SES is region based the default region has to be configured
either using `AWS_DEFAULT_REGION` environment variable or in AWS
credentials file. Same goes for AWS credentials: instances require
either an IAM role or environment variables with correct AWS tokens
(`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).

Mandrill had an option to create text email body from HTML. SES
doesn't seem to have anything similar, so for now the emails are
sent with HTML content only.
