### PR TITLE
Add a WTForms validator that checks government email addresses

### DIFF
--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -18,10 +18,15 @@ email_regex = Regexp(r'^[^@^\s]+@[\d\w-]+(\.[\d\w-]+)+$',
 def is_government_email(data_api_client):
     """
     Returns a WTForms validator that uses the api to check the email against a government domain whitelist.
+
+    Adds a flag 'non_gov' to the field for detecting if the user needs to be warned about a government email
+    restriction.  This flag is only true if the given email address is known to be non-government (and not just typoed).
     """
     def validator(form, field):
+        setattr(field.flags, 'non_gov', False)
         email_regex(form, field)
         if not data_api_client.is_email_address_with_valid_buyer_domain(field.data):
+            setattr(field.flags, 'non_gov', True)
             # wtforms wraps the label in a <label> tag
             label = do_striptags(field.label)
             raise ValidationError('{} needs to be a government email address'.format(label))

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -40,6 +40,7 @@ class TestFormHandling(BaseApplicationTest):
         with self.flask.app_context():
             form = self.build_form()
             assert form.validate()
+            assert not form.buyer_email.flags.non_gov
 
     def test_whitespace_stripping(self):
         with self.flask.app_context():
@@ -53,6 +54,7 @@ class TestFormHandling(BaseApplicationTest):
             assert not form.validate()
             assert 'buyer_email' in form.errors
             assert 'valid' in form.errors['buyer_email'][0]
+            assert not form.buyer_email.flags.non_gov
 
     def test_non_gov_email(self):
         with self.flask.app_context():
@@ -60,6 +62,7 @@ class TestFormHandling(BaseApplicationTest):
             assert not form.validate()
             assert 'buyer_email' in form.errors
             assert 'government' in form.errors['buyer_email'][0]
+            assert form.buyer_email.flags.non_gov
 
     def test_csrf_protection(self):
         with self.flask.app_context():

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,31 +1,75 @@
 # -*- coding: utf-8 -*-
 
-from dmutils.forms import DmForm, email_regex, FakeCsrf, render_template_with_csrf, StripWhitespaceStringField
+from dmutils.forms import (
+    DmForm, email_regex, FakeCsrf, is_government_email, render_template_with_csrf, StripWhitespaceStringField
+)
 
 from helpers import BaseApplicationTest
 
 
+class FakeDataApiClient(object):
+
+    def is_email_address_with_valid_buyer_domain(self, email_address):
+        return email_address and email_address.endswith('gov.au')
+
+
 class TestForm(DmForm):
     stripped_field = StripWhitespaceStringField('Stripped', id='stripped_field')
+    buyer_email = StripWhitespaceStringField(
+        'Buyer email address', id='buyer_email',
+        validators=[
+            is_government_email(FakeDataApiClient())
+        ]
+    )
 
 
 class TestFormHandling(BaseApplicationTest):
 
+    complete_form_data = {
+        'csrf_token': FakeCsrf.valid_token,
+        'stripped_field': '',
+        'buyer_email': 'asdf@example.gov.au',
+    }
+
+    def build_form(self, **kwargs):
+        data = dict(self.complete_form_data)
+        data.update(**kwargs)
+        return TestForm(**data)
+
+    def test_valid_form(self):
+        with self.flask.app_context():
+            form = self.build_form()
+            assert form.validate()
+
     def test_whitespace_stripping(self):
         with self.flask.app_context():
-            form = TestForm(stripped_field='  asdf ', csrf_token=FakeCsrf.valid_token)
+            form = self.build_form(stripped_field='  asdf ')
             assert form.validate()
             assert form.stripped_field.data == 'asdf'
 
+    def test_invalid_email(self):
+        with self.flask.app_context():
+            form = self.build_form(buyer_email='@@@')
+            assert not form.validate()
+            assert 'buyer_email' in form.errors
+            assert 'valid' in form.errors['buyer_email'][0]
+
+    def test_non_gov_email(self):
+        with self.flask.app_context():
+            form = self.build_form(buyer_email='valid@example.com')
+            assert not form.validate()
+            assert 'buyer_email' in form.errors
+            assert 'government' in form.errors['buyer_email'][0]
+
     def test_csrf_protection(self):
         with self.flask.app_context():
-            form = TestForm(stripped_field='asdf', csrf_token='bad')
+            form = self.build_form(csrf_token='bad')
             assert not form.validate()
             assert 'csrf_token' in form.errors
 
     def test_does_not_crash_on_missing_csrf_token(self):
         with self.flask.app_context():
-            form = TestForm(stripped_field='asdf')
+            form = TestForm(csrf_token=None)
             assert not form.validate()
             assert 'csrf_token' in form.errors
 


### PR DESCRIPTION
Currently this is an extra check in the request handling code.  This is
okay when there's just one email address to check in a form, but it gets
unwieldy with multiple combinations of email addresses that could be
wrong.  With this validator we can integrate with WTForms' validation.
