### PR TITLE
Pull domain checking into utils

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -1,0 +1,2 @@
+gov.au
+digital.cabinet-office.gov.uk

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -1,16 +1,10 @@
 # -*- coding: utf-8 -*-
 
 from dmutils.forms import (
-    DmForm, email_regex, FakeCsrf, is_government_email, render_template_with_csrf, StripWhitespaceStringField
+    DmForm, email_validator, FakeCsrf, government_email_validator, render_template_with_csrf, StripWhitespaceStringField
 )
 
 from helpers import BaseApplicationTest
-
-
-class FakeDataApiClient(object):
-
-    def is_email_address_with_valid_buyer_domain(self, email_address):
-        return email_address and email_address.endswith('gov.au')
 
 
 class TestForm(DmForm):
@@ -18,7 +12,7 @@ class TestForm(DmForm):
     buyer_email = StripWhitespaceStringField(
         'Buyer email address', id='buyer_email',
         validators=[
-            is_government_email(FakeDataApiClient())
+            government_email_validator,
         ]
     )
 
@@ -94,7 +88,7 @@ def test_valid_email_formats():
         'good@hyphenated-subdomain.example.com',
     ]
     for address in cases:
-        assert email_regex.regex.match(address) is not None, address
+        assert email_validator.regex.match(address) is not None, address
 
 
 def test_invalid_email_formats():
@@ -113,4 +107,4 @@ def test_invalid_email_formats():
         'bad@example.com,other.example.com',
     ]
     for address in cases:
-        assert email_regex.regex.match(address) is None, address
+        assert email_validator.regex.match(address) is None, address


### PR DESCRIPTION
Previously, buyer domain checking was an RPC to the API.  Now it's just
a function in the utils.  The core functionality is just copied as-is
from the API code.

The list of valid domains couldn't be updated without a restart of the API
anyway.  It's theoretically possible to add live updating support, but
we probably won't because we won't need it.  We can do zero-downtime
updates to the frontend code anyway, so this approach gives us simpler
code and less stuff to mock in test cases.

I also took the opportunity to give the email validation routines more
descriptive and consistent names.
