### PR TITLE
Put government domains into code

### DIFF
--- a/data/buyer-email-domains.txt
+++ b/data/buyer-email-domains.txt
@@ -1,2 +1,0 @@
-gov.au
-digital.cabinet-office.gov.uk

--- a/dmutils/forms.py
+++ b/dmutils/forms.py
@@ -15,12 +15,15 @@ email_validator = Regexp(r'^[^@^\s]+@[\d\w-]+(\.[\d\w-]+)+$',
                          message='You must provide a valid email address')
 
 
-_BUYER_EMAIL_DOMAINS = [l.strip() for l in open('./data/buyer-email-domains.txt', 'rt')]
+_GOV_EMAIL_DOMAINS = [
+    'gov.au',
+    'digital.cabinet-office.gov.uk',
+]
 
 
 def is_government_email(email_address):
     domain = email_address.split('@')[-1]
-    return any(domain == d or domain.endswith('.' + d) for d in _BUYER_EMAIL_DOMAINS)
+    return any(domain == d or domain.endswith('.' + d) for d in _GOV_EMAIL_DOMAINS)
 
 
 def government_email_validator(form, field):


### PR DESCRIPTION
We can put them back into an external file later if needed, but that'll
require some proper file management in the deployment.  We don't need it
now, so I'll do this for simplicity.
