### PR TITLE
Handle BASE_TEMPLATE_DATA in the utils

### DIFF
--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -5,6 +5,7 @@ from flask import Markup, redirect, request, session
 from flask.ext.script import Manager, Server
 from flask_login import current_user
 
+from asset_fingerprint import AssetFingerprinter
 from user import User, user_logging_string
 
 
@@ -53,12 +54,6 @@ def init_app(
     def add_header(response):
         response.headers['X-Frame-Options'] = 'DENY'
         return response
-
-    @application.context_processor
-    def inject_global_template_variables():
-        return dict(
-            pluralize=pluralize,
-            **(application.config['BASE_TEMPLATE_DATA'] or {}))
 
 
 def init_frontend_app(application, data_api_client, login_manager):
@@ -113,6 +108,16 @@ def init_frontend_app(application, data_api_client, login_manager):
             response.cache_control.max_age = application.config['DM_DEFAULT_CACHE_MAX_AGE']
 
         return response
+
+    @application.context_processor
+    def inject_global_template_variables():
+        template_data = {
+            'pluralize': pluralize,
+            'header_class': 'with-proposition',
+            'asset_path': application.config['ASSET_PATH'] + '/',
+            'asset_fingerprinter': AssetFingerprinter(asset_root=application.config['ASSET_PATH'] + '/')
+        }
+        return template_data
 
     @application.template_filter('markdown')
     def markdown_filter_flask(data):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -28,7 +28,7 @@ class Config(object):
     CSRF_TIME_LIMIT = 30
     DM_DEFAULT_CACHE_MAX_AGE = 60
     SECRET_KEY = 'secret'
-    BASE_TEMPLATE_DATA = {}
+    ASSET_PATH = '/static'
 
 
 class BaseApplicationTest(object):


### PR DESCRIPTION
Currently all the frontends are handling this separately in their
configs.  But this stops ASSET_PATH being handled correctly if it's
set in an environment variable.

All the frontends are copying the same code for this anyway, and if one
frontend needs a new variable, there's probably no harm letting other frontends
have it, too.  In the worst case, extra variables can be injected per
frontend if really needed.
