### PR TITLE
Log the file watching message instead of printing it

### DIFF
--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -163,7 +163,7 @@ def init_manager(application, port, extra_directories=()):
 
     extra_files = list(get_extra_files(extra_directories))
 
-    print("Watching {} extra files".format(len(extra_files)))
+    application.logger.info("Watching {} extra files".format(len(extra_files)))
 
     manager.add_command(
         "runserver",

--- a/tests/test_flask_init.py
+++ b/tests/test_flask_init.py
@@ -1,6 +1,6 @@
 from flask.ext.cache import Cache
 
-from dmutils.flask_init import pluralize, init_app, init_frontend_app
+from dmutils.flask_init import pluralize, init_app, init_frontend_app, init_manager
 from helpers import BaseApplicationTest, Config
 
 import pytest
@@ -35,3 +35,9 @@ class TestProdCacheInit(BaseApplicationTest):
 
     def test_config(self):
         assert self.cache.config['CACHE_TYPE'] == 'filesystem'
+
+
+class TestInitManager(BaseApplicationTest):
+
+    def test_init_manager(self):
+        manager = init_manager(self.flask, 5000, [])


### PR DESCRIPTION
This keeps the message out of standard output and puts it in standard
error with the other messages.
