### PR TITLE
Use timezones consistently when rendering dates

### DIFF
--- a/dmutils/flask_init.py
+++ b/dmutils/flask_init.py
@@ -148,11 +148,13 @@ def init_frontend_app(application, data_api_client, login_manager):
     def markdown_filter_flask(data):
         return Markup(filters.markdown_filter(data))
     application.add_template_filter(filters.format_links)
-    application.add_template_filter(formats.timeformat)
-    application.add_template_filter(formats.shortdateformat)
-    application.add_template_filter(formats.dateformat)
-    application.add_template_filter(formats.datetimeformat)
     application.add_template_filter(filters.smartjoin)
+
+    date_formatter = formats.DateFormatter(application.config['DM_TIMEZONE'])
+    application.add_template_filter(date_formatter.timeformat)
+    application.add_template_filter(date_formatter.shortdateformat)
+    application.add_template_filter(date_formatter.dateformat)
+    application.add_template_filter(date_formatter.datetimeformat)
 
 
 def pluralize(count, singular, plural):

--- a/dmutils/formats.py
+++ b/dmutils/formats.py
@@ -33,36 +33,29 @@ LOTS = [
 ]
 
 
-def timeformat(value, default_value=None):
-    return _format_date(value, default_value, DISPLAY_TIME_FORMAT)
+class DateFormatter(object):
 
+    def __init__(self, tz_name='UTC'):
+        self.timezone = pytz.timezone(tz_name)
 
-def shortdateformat(value, default_value=None):
-    return _format_date(value, default_value, DISPLAY_SHORT_DATE_FORMAT, localize=False)
+    def _format(self, value, fmt):
+        if not isinstance(value, datetime):
+            value = datetime.strptime(value, DATETIME_FORMAT)
+        if value.tzinfo is None:
+            value = pytz.utc.localize(value)
+        return value.astimezone(self.timezone).strftime(fmt)
 
+    def timeformat(self, value):
+        return self._format(value, DISPLAY_TIME_FORMAT)
 
-def dateformat(value, default_value=None):
-    return _format_date(value, default_value, DISPLAY_DATE_FORMAT, localize=False)
+    def shortdateformat(self, value):
+        return self._format(value, DISPLAY_SHORT_DATE_FORMAT)
 
+    def dateformat(self, value):
+        return self._format(value, DISPLAY_DATE_FORMAT)
 
-def datetimeformat(value, default_value=None):
-    return _format_date(value, default_value, DISPLAY_DATETIME_FORMAT)
-
-
-EUROPE_LONDON = pytz.timezone("Europe/London")
-
-
-def _format_date(value, default_value, fmt, localize=True):
-    if not value:
-        return default_value
-    if not isinstance(value, datetime):
-        value = datetime.strptime(value, DATETIME_FORMAT)
-    if value.tzinfo is None:
-        value = pytz.utc.localize(value)
-    if localize:
-        return value.astimezone(EUROPE_LONDON).strftime(fmt)
-    else:
-        return value.strftime(fmt)
+    def datetimeformat(self, value):
+        return self._format(value, DISPLAY_DATETIME_FORMAT)
 
 
 def lot_to_lot_case(lot_to_check):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -32,6 +32,7 @@ class Config(object):
     ASSET_PATH = '/static'
     DM_HTTP_PROTO = 'http'
     URL_PREFIX = ''
+    DM_TIMEZONE = 'Australia/Sydney'
 
 
 class BaseApplicationTest(object):

--- a/tests/test_flask_init.py
+++ b/tests/test_flask_init.py
@@ -1,3 +1,4 @@
+from flask import render_template_string
 import flask_featureflags
 from flask_cache import Cache
 
@@ -57,3 +58,32 @@ class TestFeatureFlags(BaseApplicationTest):
         with self.flask.app_context():
             assert flask_featureflags.is_active('YES')
             assert not flask_featureflags.is_active('NO')
+
+
+class TestTemplateFilters(BaseApplicationTest):
+
+    # formats themselves are tested in test_formats
+
+    def test_timeformat(self):
+        with self.flask.app_context():
+            template = '{{ "2000-01-01T00:00:00.000000Z"|timeformat }}'
+            result = render_template_string(template)
+            assert result.strip()
+
+    def test_shortdateformat(self):
+        with self.flask.app_context():
+            template = '{{ "2000-01-01T00:00:00.000000Z"|shortdateformat }}'
+            result = render_template_string(template)
+            assert result.strip()
+
+    def test_dateformat(self):
+        with self.flask.app_context():
+            template = '{{ "2000-01-01T00:00:00.000000Z"|dateformat }}'
+            result = render_template_string(template)
+            assert result.strip()
+
+    def test_datetimeformat(self):
+        with self.flask.app_context():
+            template = '{{ "2000-01-01T00:00:00.000000Z"|datetimeformat }}'
+            result = render_template_string(template)
+            assert result.strip()

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-from dmutils.formats import (
-    get_label_for_lot_param, lot_to_lot_case,
-    timeformat, shortdateformat, dateformat, datetimeformat
-)
+from dmutils.formats import DateFormatter, get_label_for_lot_param, lot_to_lot_case
+
 import pytz
 from datetime import datetime
 import pytest
@@ -37,73 +35,63 @@ class TestFormats(object):
             assert get_label_for_lot_param(example) == expected
 
 
-def test_timeformat():
-    cases = [
-        (datetime(2012, 11, 10, 9, 8, 7, 6), "09:08:07"),
-        ("2012-11-10T09:08:07.0Z", "09:08:07"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6), "10:08:07"),
-        ("2012-08-12T12:12:12.0Z", "13:12:12"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10:08:07"),
-        (datetime(2012, 8, 10, 0, 8, 7, 6, tzinfo=pytz.utc), "01:08:07"),
-    ]
+class TestDateFormats(object):
 
-    def check_timeformat(dt, formatted_time):
-        assert timeformat(dt) == formatted_time
+    def setup(self):
+        self.formatter = DateFormatter('Europe/London')
 
-    for dt, formatted_time in cases:
-        yield check_timeformat, dt, formatted_time
+    def test_timeformat(self):
+        cases = [
+            (datetime(2012, 11, 10, 9, 8, 7, 6), '09:08:07'),
+            ('2012-11-10T09:08:07.0Z', '09:08:07'),
+            (datetime(2012, 8, 10, 9, 8, 7, 6), '10:08:07'),
+            ('2012-08-12T12:12:12.0Z', '13:12:12'),
+            (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), '10:08:07'),
+            (datetime(2012, 8, 10, 0, 8, 7, 6, tzinfo=pytz.utc), '01:08:07'),
+        ]
 
+        for dt, formatted_time in cases:
+            assert self.formatter.timeformat(dt) == formatted_time
 
-def test_shortdateformat():
-    cases = [
-        (datetime(2012, 11, 10, 9, 8, 7, 6), "10 November"),
-        ("2012-11-10T09:08:07.0Z", "10 November"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6), "10 August"),
-        ("2012-08-10T09:08:07.0Z", "10 August"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "10 August"),
-        ("2016-04-27T23:59:59.0Z", "27 April"),
-        (datetime(2016, 4, 27, 23, 59, 59, 0, tzinfo=pytz.utc), "27 April"),
-        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "1 August"),
-    ]
+    def test_shortdateformat(self):
+        cases = [
+            (datetime(2012, 11, 10, 9, 8, 7, 6), '10 November'),
+            ('2012-11-10T09:08:07.0Z', '10 November'),
+            (datetime(2012, 8, 10, 9, 8, 7, 6), '10 August'),
+            ('2012-08-10T09:08:07.0Z', '10 August'),
+            (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), '10 August'),
+            ('2016-04-27T23:59:59.0Z', '28 April'),
+            (datetime(2016, 4, 27, 23, 59, 59, 0, tzinfo=pytz.utc), '28 April'),
+            (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), '1 August'),
+        ]
 
-    def check_shortdateformat(dt, formatted_date):
-        assert shortdateformat(dt) == formatted_date
+        for dt, formatted_date in cases:
+            assert self.formatter.shortdateformat(dt) == formatted_date
 
-    for dt, formatted_date in cases:
-        yield check_shortdateformat, dt, formatted_date
+    def test_dateformat(self):
+        cases = [
+            (datetime(2012, 11, 10, 9, 8, 7, 6), 'Saturday 10 November 2012'),
+            ('2012-11-10T09:08:07.0Z', 'Saturday 10 November 2012'),
+            (datetime(2012, 8, 10, 9, 8, 7, 6), 'Friday 10 August 2012'),
+            ('2012-08-10T09:08:07.0Z', 'Friday 10 August 2012'),
+            (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), 'Friday 10 August 2012'),
+            ('2016-04-27T23:59:59.0Z', 'Thursday 28 April 2016'),
+            (datetime(2016, 4, 27, 23, 59, 59, 0), 'Thursday 28 April 2016'),
+            (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), 'Wednesday 1 August 2012'),
+        ]
 
+        for dt, formatted_date in cases:
+            assert self.formatter.dateformat(dt) == formatted_date
 
-def test_dateformat():
-    cases = [
-        (datetime(2012, 11, 10, 9, 8, 7, 6), "Saturday 10 November 2012"),
-        ("2012-11-10T09:08:07.0Z", "Saturday 10 November 2012"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012"),
-        ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012"),
-        ("2016-04-27T23:59:59.0Z", "Wednesday 27 April 2016"),
-        (datetime(2016, 4, 27, 23, 59, 59, 0), "Wednesday 27 April 2016"),
-        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012"),
-    ]
+    def test_datetimeformat(self):
+        cases = [
+            (datetime(2012, 11, 10, 9, 8, 7, 6), 'Saturday 10 November 2012 at 09:08'),
+            ('2012-11-10T09:08:07.0Z', 'Saturday 10 November 2012 at 09:08'),
+            (datetime(2012, 8, 10, 9, 8, 7, 6), 'Friday 10 August 2012 at 10:08'),
+            ('2012-08-10T09:08:07.0Z', 'Friday 10 August 2012 at 10:08'),
+            (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), 'Friday 10 August 2012 at 10:08'),
+            (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), 'Wednesday 1 August 2012 at 10:08'),
+        ]
 
-    def check_dateformat(dt, formatted_date):
-        assert dateformat(dt) == formatted_date
-
-    for dt, formatted_date in cases:
-        yield check_dateformat, dt, formatted_date
-
-
-def test_datetimeformat():
-    cases = [
-        (datetime(2012, 11, 10, 9, 8, 7, 6), "Saturday 10 November 2012 at 09:08"),
-        ("2012-11-10T09:08:07.0Z", "Saturday 10 November 2012 at 09:08"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6), "Friday 10 August 2012 at 10:08"),
-        ("2012-08-10T09:08:07.0Z", "Friday 10 August 2012 at 10:08"),
-        (datetime(2012, 8, 10, 9, 8, 7, 6, tzinfo=pytz.utc), "Friday 10 August 2012 at 10:08"),
-        (datetime(2012, 8, 1, 9, 8, 7, 6, tzinfo=pytz.utc), "Wednesday 1 August 2012 at 10:08"),
-    ]
-
-    def check_datetimeformat(dt, formatted_datetime):
-        assert datetimeformat(dt) == formatted_datetime
-
-    for dt, formatted_datetime in cases:
-        yield check_datetimeformat, dt, formatted_datetime
+        for dt, formatted_datetime in cases:
+            assert self.formatter.datetimeformat(dt) == formatted_datetime


### PR DESCRIPTION
When rendering a date without a time in the UK, the difference between
local time and UTC is only noticeable for a short period around
midnight.  The difference is much more noticeable in Australia.
