### PR TITLE
Add min field length validation

### DIFF
--- a/react/response.py
+++ b/react/response.py
@@ -22,6 +22,15 @@ def from_response(request):
 def validate_form_data(data, required_fields):
     errors = {}
     for field in required_fields:
-        if not data.get(field, None) or not data.get(field)[0]:
-            errors[field] = {"required": True}
+        name = field[0] if isinstance(field, tuple) else field
+        if not data.get(name, None) or not data.get(name)[0]:
+            errors[name] = {"required": True}
+            continue
+
+        length = field[1] if isinstance(field, tuple) else None
+        if length and len(data.get(name)) < length:
+            errors[name] = {"min": True}
+
     return errors
+
+

--- a/react/response.py
+++ b/react/response.py
@@ -32,5 +32,3 @@ def validate_form_data(data, required_fields):
             errors[name] = {"min": True}
 
     return errors
-
-

--- a/tests/test_render_server.py
+++ b/tests/test_render_server.py
@@ -119,11 +119,17 @@ class TestReactResponse(BaseApplicationTest):
     def test_valid_form(self):
         data = {'key1': 'value1', 'key2': 'value2'}
         required_fields = ['key1', 'key2']
+        min_fields = ['key1', ('key2', 5)]
         assert not validate_form_data(data, required_fields)
+        assert not validate_form_data(data, min_fields)
 
     def test_invalid_form(self):
         data = {'key1': 'value1'}
         required_fields = ['key1', 'key2']
+        min_fields = [('key1', 10)]
         errors = validate_form_data(data, required_fields)
+        min_errors = validate_form_data(data, min_fields)
         assert 'key2' in errors
         assert errors['key2'] == {"required": True}
+        assert 'key1' in min_errors
+        assert min_errors['key1'] == {"min": True}


### PR DESCRIPTION
Can now optionally include a field length when validating:

   `validate_form_data(data, [('password', 10), 'username'])`